### PR TITLE
Allow the mapgen to go higher!

### DIFF
--- a/mods/default/mapgen.lua
+++ b/mods/default/mapgen.lua
@@ -67,7 +67,6 @@ minetest.register_ore({
 	clust_size     = 6,
 	height_min     = -31000,
 	height_max     = 0,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -101,7 +100,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -64,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -113,7 +111,6 @@ minetest.register_ore({
 	clust_size     = 6,
 	height_min     = -31000,
 	height_max     = -64,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -125,7 +122,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -255,
 	height_max     = -64,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -137,7 +133,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -149,7 +144,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -1024,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -161,7 +155,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -255,
 	height_max     = -64,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -173,7 +166,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -185,7 +177,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -208,71 +199,7 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -64,
-	flags          = "absheight",
 })
-
-if minetest.setting_get("mg_name") == "indev" then
-	-- Floatlands and high mountains springs
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:water_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 40*40*40,
-		clust_num_ores = 8,
-		clust_size     = 3,
-		height_min     = 100,
-		height_max     = 31000,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:lava_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 50*50*50,
-		clust_num_ores = 5,
-		clust_size     = 2,
-		height_min     = 10000,
-		height_max     = 31000,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:sand",
-		wherein        = "default:stone",
-		clust_scarcity = 20*20*20,
-		clust_num_ores = 5*5*3,
-		clust_size     = 5,
-		height_min     = 500,
-		height_max     = 31000,
-	})
-
-	-- Underground springs
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:water_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 25*25*25,
-		clust_num_ores = 8,
-		clust_size     = 3,
-		height_min     = -10000,
-		height_max     = -10,
-	})
-
-	minetest.register_ore({
-		ore_type       = "scatter",
-		ore            = "default:lava_source",
-		ore_param2     = 128,
-		wherein        = "default:stone",
-		clust_scarcity = 35*35*35,
-		clust_num_ores = 5,
-		clust_size     = 2,
-		height_min     = -31000,
-		height_max     = -100,
-	})
-end
 
 minetest.register_ore({
 	ore_type       = "scatter",

--- a/mods/lottmapgen/init.lua
+++ b/mods/lottmapgen/init.lua
@@ -94,7 +94,7 @@ dofile(minetest.get_modpath("lottmapgen").."/functions.lua")
 
 -- On generated function
 minetest.register_on_generated(function(minp, maxp, seed)
-	if minp.y < (mapgen_params.water_level-86) or minp.y > 208 then
+	if minp.y < (mapgen_params.water_level-86) or minp.y > 5000 then
 		return
 	end
 
@@ -217,7 +217,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 			local water = false -- water node above?
 			local surfy = y1 + 80 -- y of last surface detected
 			for y = y1, y0, -1 do -- working down each column for each node do
-				local fimadep = math.floor(6 - y / 16) + math.random(0, 1)
+				local fimadep = math.floor(6 - y / 512) + math.random(0, 1)
 				local vi = area:index(x, y, z)
 				local nodid = data[vi]
 				local viuu = area:index(x, y - 2, z)

--- a/mods/lottores/init.lua
+++ b/mods/lottores/init.lua
@@ -133,7 +133,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -61,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -145,7 +144,6 @@ minetest.register_ore({
 	clust_size     = 6,
 	height_min     = -31000,
 	height_max     = -50,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -157,7 +155,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -200,
 	height_max     = -50,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -169,7 +166,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -201,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -192,7 +188,6 @@ minetest.register_ore({
 	clust_size     = 5,
 	height_min     = -31000,
 	height_max     = -61,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -215,7 +210,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -61,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -227,7 +221,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -300,
 	height_max     = -70,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -239,7 +232,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -301,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -251,7 +243,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 minetest.register_ore({
 	ore_type       = "scatter",
@@ -262,7 +253,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 minetest.register_ore({
 	ore_type       = "scatter",
@@ -273,7 +263,6 @@ minetest.register_ore({
 	clust_size     = 2,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 
 
@@ -286,7 +275,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -255,
 	height_max     = -128,
-	flags          = "absheight",
 })
 
 minetest.register_ore({
@@ -298,7 +286,6 @@ minetest.register_ore({
 	clust_size     = 3,
 	height_min     = -31000,
 	height_max     = -256,
-	flags          = "absheight",
 })
 
 -- Craft Items


### PR DESCRIPTION
This removes the "absheight" param, which makes ores generate at their positive numbers, which, with lottmapgen, looks a mess, as well as allowing people to gather ores on the surface high in the mountains... 
I also made the max y coord for voxelmanip higher, allowing the mapgen to actually work higher! (I put it to 5000, I'm unsure whether to knock it up to ~31,000...)
To make dirt with grass generate higher, I knocked the number which is used as the divisor in the calculation to work out fimadep up to 512 from 16... It **should** be good until ~3000... Again, I could increase this number so it's good till 31,000...
I removed some code for the obsolete indev mapgen.

![screenshot_20150427_124504](https://cloud.githubusercontent.com/assets/4390945/7358812/3c78ec8c-ed30-11e4-8854-681d1caf640c.png)
This is now possible! (Along with many higher things!)
