### PR TITLE
Tell GitHub not to show language statistics for .x files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.x linguist-vendored


### PR DESCRIPTION
This makes the statistics be 100% Lua.