### PR TITLE
Badtoad2000 patch 1

### DIFF
--- a/mods/default/crafting.lua
+++ b/mods/default/crafting.lua
@@ -323,7 +323,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'default:sandstone 2',
+	output = 'default:sandstone',
 	recipe = {
 		{'group:sand', 'group:sand'},
 		{'group:sand', 'group:sand'},

--- a/mods/lottplants/functions.lua
+++ b/mods/lottplants/functions.lua
@@ -613,7 +613,7 @@ local function can_grow(pos)
 		return false
 	end
 	local is_soil = minetest.get_item_group(node.name, "soil")
-	local is_soil = minetest.get_item_group(node.name, "sand")
+	local is_sand = minetest.get_item_group(node.name, "sand")
 	local is_stone = minetest.get_item_group(node.name, "stone")
 	if is_soil == 0 and is_sand == 0 and is_stone == 0 then
 		return false


### PR DESCRIPTION
Howdy,

Noticed a couple "sand" issues. The first is merely a typo in your last update, and the second has to do with back-and-forth conversion of sand/sandstone resulting in doubling of said items.

BTW for the can_grow function it may have been cleaner to use an array of values you wish to check and iterate over it (see below):

local function can_grow(pos)
        local node = minetest.get_node_or_nil({x = pos.x, y = pos.y, z = pos.z})
        if not node then
                return false
        end
        local growable_nodes = { "soil", "sand", "stone" }
        for i, growable_node in ipairs (growable_nodes) do
                if minetest.get_item_group(node.name, growable_node) ~= 0 then
                        return true
                end
        end
        return false
end

Maybe next time.